### PR TITLE
Cleanup of recv_packet and Favorites list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build/
 MANIFEST
 MYNOTES
 example.py
+venv
+*.out

--- a/mooltipy/mooltipass.py
+++ b/mooltipy/mooltipass.py
@@ -42,6 +42,7 @@ class _Mooltipass(object):
     Server / App-Mooltiplass relationship.
     """
 
+    _PKT_LEN_INDEX = 0x00
     _CMD_INDEX = 0x01
     _DATA_INDEX = 0x02
 
@@ -148,11 +149,11 @@ class _Mooltipass(object):
             recv = self._epin.read(self._epin.wMaxPacketSize, timeout=timeout)
             #logging.debug('\n\t' + str(recv))
             if recv is not None:
-                if recv[1] == 0xB9:
+                if recv[self._CMD_INDEX] == 0xB9:
                     # Unit sends 0xB9 when user is entering their PIN.
                     break
-                elif recv[1] == CMD_DEBUG:
-                    debug_msg = struct.unpack('{}s'.format(recv[0]-1), recv[2:recv[0]+1])[0]
+                elif recv[self._CMD_INDEX] == CMD_DEBUG:
+                    debug_msg = struct.unpack('{}s'.format(recv[self._PKT_LEN_INDEX]-1), recv[self._DATA_INDEX:recv[self._PKT_LEN_INDEX]+1])[0]
                     if debug_msg == "#MBE":
                         print("Received Memory Boundary Error Callback!")
                     elif debug_msg == "#NM":
@@ -163,7 +164,7 @@ class _Mooltipass(object):
                         print("Received unknown debug message {}".format(debug_msg))
                     print('Exiting...')
                     sys.exit(1)
-                elif recv[1] == 0xC4:
+                elif recv[self._CMD_INDEX] == 0xC4:
                     # The mooltipass may request the client resend its
                     # previous packet. I have not yet encountered this, but
                     # I guess it should be passed back to the calling
@@ -178,9 +179,10 @@ class _Mooltipass(object):
                 else:
                     break
             time.sleep(.5)
-        logging.debug('RX Packet - CMD:0x{:x} Length:{}'.format(recv[1], recv[0]))
-        logging.debug('{}'.format(recv[2:]))
-        return recv
+        logging.debug('RX Packet - CMD:0x{:x} Length:{}'.format(recv[self._CMD_INDEX], recv[self._PKT_LEN_INDEX]))
+        logging.debug('{}'.format(recv[self._DATA_INDEX:]))
+        # -1 for the command byte
+        return recv[self._DATA_INDEX:], recv[self._PKT_LEN_INDEX]-1
 
     def ping(self, data):
         """Ping the mooltipass. (0xA1)
@@ -220,7 +222,9 @@ class _Mooltipass(object):
                         Eg. "v1"
         """
         self.send_packet(CMD_VERSION, None)
-        return self.recv_packet()
+        recv, recv_len = self.recv_packet()
+        # -1 byte for flash size
+        return struct.unpack('<b{}s'.format(recv_len-1), recv[0:recv_len])
 
     def set_context(self, context):
         """Set mooltipass context. (0xA3)
@@ -235,7 +239,8 @@ class _Mooltipass(object):
         """
 
         self.send_packet(CMD_CONTEXT, array('B', context + b'\x00'))
-        return self.recv_packet(10000)[self._DATA_INDEX]
+        recv, _ = self.recv_packet(10000)
+        return recv[0]
 
     def get_login(self):
         """Get the login for current context. (0xA4)
@@ -243,11 +248,11 @@ class _Mooltipass(object):
         Returns the login as a string or 0 on failure.
         """
         self.send_packet(CMD_GET_LOGIN, None)
-        recv = self.recv_packet()[self._DATA_INDEX:]
+        recv, recv_len = self.recv_packet()
         if recv[0] == 0x00:
             return 0
         else:
-            return struct.unpack('<{}s'.format(len(recv)), recv)[0].strip('\0')
+            return struct.unpack('<{}s'.format(recv_len), recv)[0].strip('\0')
 
     def get_password(self):
         """Get the password for current context. (0xA5)
@@ -255,11 +260,11 @@ class _Mooltipass(object):
         Returns the password as a string or 0 on failure.
         """
         self.send_packet(CMD_GET_PASSWORD, None)
-        recv = self.recv_packet()[self._DATA_INDEX:]
+        recv, recv_len = self.recv_packet()[self._DATA_INDEX:]
         if recv[0] == 0x00:
             return 0
         else:
-            return struct.unpack('<{}s'.format(len(recv)), recv)[0].strip('\0')
+            return struct.unpack('<{}s'.format(recv_len), recv)[0].strip('\0')
 
     def set_login(self, login):
         """Set a login. (0xA6)
@@ -267,7 +272,8 @@ class _Mooltipass(object):
         Return 1 or 0 indicating success or failure.
         """
         self.send_packet(CMD_SET_LOGIN, array('B', login + b'\x00'))
-        return self.recv_packet()[self._DATA_INDEX]
+        recv, _ = self.recv_packet()
+        return recv[0]
 
     def set_password(self, password):
         """Set a password for current context. (0xA7)
@@ -275,7 +281,8 @@ class _Mooltipass(object):
         Return 1 or 0 indicating success or failure.
         """
         self.send_packet(CMD_SET_PASSWORD, array('B', password + b'\x00'))
-        return self.recv_packet()[self._DATA_INDEX]
+        recv, _ = self.recv_packet()
+        return recv[0]
 
     def check_password(self, password):
         """Compare given password to set password for context. (0xA8)
@@ -288,7 +295,8 @@ class _Mooltipass(object):
         self.send_packet(CMD_CHECK_PASSWORD, array('B', password + b'\x00'))
         recv = None
         while recv is None or recv == 0x02:
-            recv = self.recv_packet()[self._DATA_INDEX]
+            recv, _ = self.recv_packet()
+            recv = recv[0]
         return recv
 
     def add_context(self, context):
@@ -297,7 +305,8 @@ class _Mooltipass(object):
         Return 1 or 0 indicating success or failure.
         """
         self.send_packet(CMD_ADD_CONTEXT, array('B', context + b'\x00'))
-        return self.recv_packet()[self._DATA_INDEX]
+        recv, _ = self.recv_packet()
+        return recv[0]
         # TODO: Is there any way to delete contexts?
 
     def _set_bootloader_password(self, password):
@@ -315,7 +324,8 @@ class _Mooltipass(object):
         # TODO: Is this intended to be directly used in generation of
         #   a random password, or as seed in external PRNG?
         self.send_packet(CMD_GET_RANDOM_NUMBER, None)
-        return self.recv_packet()[self._DATA_INDEX]
+        recv, _ = self.recv_packet()
+        return recv[0]
 
     def start_memory_management(self, timeout=20000):
         """Enter memory management mode. (0xAD)
@@ -328,7 +338,8 @@ class _Mooltipass(object):
         """
         print('Accept memory management mode to continue...')
         self.send_packet(CMD_START_MEMORYMGMT, None)
-        return self.recv_packet(timeout)
+        recv, _ = self.recv_packet(timeout)
+        return recv[0]
 
     def _start_media_import(self):
         """Request send media to Mooltipass. (0xAE)
@@ -458,7 +469,8 @@ class _Mooltipass(object):
         # Make constants, create list of invalid combinations and raise
         # error if encountered.
         self.send_packet(CMD_MOOLTIPASS_STATUS, None)
-        return self.recv_packet()[self._DATA_INDEX]
+        recv, _ = self.recv_packet()
+        return recv[0]
 
     # Where is 0xBA?
 
@@ -483,7 +495,8 @@ class _Mooltipass(object):
         Return 1 or 0 indicating success or failure.
         """
         self.send_packet(CMD_SET_DATA_SERVICE, array('B', context + b'\x00'))
-        return self.recv_packet()[self._DATA_INDEX]
+        recv, _ = self.recv_packet()
+        return recv[0]
 
     def add_data_context(self, context):
         """Add a data context. (0xBF)
@@ -495,7 +508,8 @@ class _Mooltipass(object):
         """
         print('sending ' + context)
         self.send_packet(CMD_ADD_DATA_SERVICE, array('B', context + b'\x00'))
-        return self.recv_packet()[self._DATA_INDEX]
+        recv, _ = self.recv_packet()
+        return recv[0]
 
     def write_data_context(self, data):
         """Write to data context in blocks of 32 bytes. (0xC0)
@@ -525,7 +539,8 @@ class _Mooltipass(object):
                 packet.extend(data[i:i+BLOCK_SIZE])
                 self.send_packet(CMD_WRITE_32B_IN_DN, packet)
                 logging.debug('wrote {0} of {1} bytes...'.format(str(i+32), str(len(data))))
-                if eod == 0 and not self.recv_packet()[self._DATA_INDEX]:
+                recv, _ = self.recv_packet()
+                if eod == 0 and not recv[0]:
                     raise RuntimeError('Unexpected return')
 
             return True
@@ -546,12 +561,12 @@ class _Mooltipass(object):
 
         while True:
             self.send_packet(CMD_READ_32B_IN_DN, None)
-            recv = self.recv_packet(5000)
-            if len(recv) < 4:
+            recv, recv_len = self.recv_packet(5000)
+            if recv_len < 4:
                 print(recv)
-            if recv[0] == 0x01:
+            if recv_len == 0x01:
                 break
-            data.extend(recv[self._DATA_INDEX:32+self._DATA_INDEX])
+            data.extend(recv[:32])
             logging.debug('Received {0} bytes...'.format(str(len(data))))
 
         return data
@@ -647,24 +662,22 @@ class _Mooltipass(object):
         data = array('B', node_addr)
         self.send_packet(CMD_READ_FLASH_NODE, data)
 
-        recv = self.recv_packet()
-        recv_size = recv[0]
+        recv, recv_size = self.recv_packet()
         try:
-            while recv_size == 62:
-                recv_extra = self.recv_packet()
-                recv_size = recv_extra[0]
-                recv.extend(recv_extra[self._DATA_INDEX:])
+            while recv_size == 61:
+                recv_extra, recv_size = self.recv_packet()
+                recv.extend(recv_extra)
         except usb.core.USBError:
             # Skip timeout once all packets are recieved
             pass
 
         # Use flags to figure out the node type
-        flags = struct.unpack('<H', recv[self._DATA_INDEX:self._DATA_INDEX+2])[0]
+        flags = struct.unpack('<H', recv[:2])[0]
         if flags & 0xC000 == 0x00:
             # This is a parent node
             prev_parent_addr, next_parent_addr, next_child_addr = \
-                struct.unpack('<HHH', recv[self._DATA_INDEX+2:self._DATA_INDEX+8])
-            recv = recv[self._DATA_INDEX+8:self._DATA_INDEX+66]
+                struct.unpack('<HHH', recv[2:8])
+            recv = recv[8:66]
             service_name = struct.unpack('<{}s'.format(len(recv)), recv)[0].strip('\0')
             return self.ParentNode(
                 node_number,
@@ -676,7 +689,7 @@ class _Mooltipass(object):
 
         elif flags & 0xC000 == 0x4000:
             # This is a credential child node
-            prev_child_addr, next_child_addr, descr, date_created, date_last_used, ctr1, ctr2, ctr3, login, password = struct.unpack("<HH24sHH3b63s32s", recv[self._DATA_INDEX+2:self._DATA_INDEX+132])
+            prev_child_addr, next_child_addr, descr, date_created, date_last_used, ctr1, ctr2, ctr3, login, password = struct.unpack("<HH24sHH3b63s32s", recv[2:132])
             ctr = (ctr1 << 16) + (ctr2 << 8) + ctr3
             return self.ChildNode(node_number, flags, prev_child_addr, next_child_addr, descr[0], date_created, date_last_used, ctr, login, password)
         elif flags & 0xC000 == 0x8000:
@@ -729,8 +742,8 @@ class _Mooltipass(object):
         address is 2 bytes).
         """
         self.send_packet(CMD_GET_FAVORITE, array('B', [slot_id]))
-        packet = self.recv_packet()[self._DATA_INDEX:]
-        return struct.unpack('<HH', packet[0:4])
+        recv, recv_len = self.recv_packet()
+        return struct.unpack('<HH', recv[0:4])
 
     def set_favorite(self, slot_id, addr_tuple):
         """Set a favorite. (0xC8)
@@ -747,7 +760,8 @@ class _Mooltipass(object):
                       addr_tuple[1]&0xFF, (addr_tuple[1]&0xFF00)>>8))
         self.send_packet(CMD_SET_FAVORITE,
                          array('B', [slot_id, addr_tuple[0]&0xFF, (addr_tuple[0]&0xFF00)>>8, addr_tuple[1]&0xFF, (addr_tuple[1]&0xFF00)>>8]))
-        return self.recv_packet()[self._DATA_INDEX:]
+        recv, _ = self.recv_packet()
+        return recv
 
     def get_starting_parent_address(self):
         """Get the address of starting parent? (0xC9)
@@ -755,9 +769,9 @@ class _Mooltipass(object):
         Return slot address or None on failure.
         """
         self.send_packet(CMD_GET_STARTING_PARENT, None)
-        recv = self.recv_packet()
+        recv, _ = self.recv_packet()
         parent_addr = \
-            struct.unpack('h', recv[self._DATA_INDEX:self._DATA_INDEX+2])[0]
+            struct.unpack('h', recv[:2])[0]
         return (lambda ret: None if 0 else ret)(parent_addr)
 
     def _set_starting_parent(self, parent_addr):
@@ -825,5 +839,6 @@ class _Mooltipass(object):
         Return 1 or 0 indicating success or failure."""
         print('Exiting memory management mode.')
         self.send_packet(CMD_END_MEMORYMGMT, None)
-        return self.recv_packet()[self._DATA_INDEX]
+        recv, _ = self.recv_packet()
+        return recv[0]
 

--- a/mooltipy/mooltipass.py
+++ b/mooltipy/mooltipass.py
@@ -251,7 +251,7 @@ class _Mooltipass(object):
         if recv[0] == 0x00:
             return 0
         else:
-            return struct.unpack('<{}s'.format(recv_len), recv)[0].strip('\0')
+            return struct.unpack('<{}s'.format(recv_len), recv[:recv_len])[0]
 
     def get_password(self):
         """Get the password for current context. (0xA5)
@@ -259,11 +259,11 @@ class _Mooltipass(object):
         Returns the password as a string or 0 on failure.
         """
         self.send_packet(CMD_GET_PASSWORD, None)
-        recv, recv_len = self.recv_packet()[self._DATA_INDEX:]
+        recv, recv_len = self.recv_packet()
         if recv[0] == 0x00:
             return 0
         else:
-            return struct.unpack('<{}s'.format(recv_len), recv)[0].strip('\0')
+            return struct.unpack('<{}s'.format(recv_len), recv[:recv_len])[0]
 
     def set_login(self, login):
         """Set a login. (0xA6)
@@ -616,7 +616,7 @@ class _Mooltipass(object):
             # Skip timeout once all packets are recieved
             pass
 
-        return recv[self._DATA_INDEX:]
+        return recv
 
     def _write_node(self, node_number, packet_number):
         """Write a node in flash. (0xC6)

--- a/mooltipy/mooltipass_client.py
+++ b/mooltipy/mooltipass_client.py
@@ -37,8 +37,8 @@ class MooltipassClient(_Mooltipass):
         if not self.ping():
             raise RuntimeError('Mooltipass did not respond to ping.')
         version_info = self.get_version()
-        self.flash_size = version_info[2]
-        self.version = version_info[3:].tostring()
+        self.flash_size = version_info[0]
+        self.version = version_info[1]
         print('Connected to Mooltipass {} w/ {} Mb Flash'.format(self.version,
               self.flash_size))
 
@@ -62,12 +62,12 @@ class MooltipassClient(_Mooltipass):
 
             recv = None
             while recv is None or \
-                    recv[self._DATA_INDEX] != data[0] or \
-                    recv[self._DATA_INDEX+1] != data[1] or \
-                    recv[self._DATA_INDEX+2] != data[2] or \
-                    recv[self._DATA_INDEX+3] != data[3]:
+                    recv[0] != data[0] or \
+                    recv[1] != data[1] or \
+                    recv[2] != data[2] or \
+                    recv[3] != data[3]:
 
-                recv = super(MooltipassClient, self).recv_packet()
+                recv, _ = super(MooltipassClient, self).recv_packet()
 
             logging.debug("Mooltipass replied to our ping message")
             return True

--- a/mooltipy/utilities/mpfavorites.py
+++ b/mooltipy/utilities/mpfavorites.py
@@ -31,7 +31,7 @@ except NameError:
     # For python 2/3 compatibility
     pass
 
-def get_all_favorites(mooltipass, args):
+def list_favorites(mooltipass, args):
     favorites = []
     for slot in range(0, 14):
         fav_slot_info = mooltipass.get_favorite(slot)
@@ -49,10 +49,7 @@ def get_all_favorites(mooltipass, args):
 
 def get_favorite(mooltipass, args):
     """Gets the favorite information from the specified slot"""
-    if args.favorite_slot == 'all':
-        get_all_favorites(mooltipass, args)
-        return
-    args.favorite_slot = int(args.favorite_slot)
+    # Argparse takes care of validation for us
     fav_slot_info = mooltipass.get_favorite(args.favorite_slot)
     if fav_slot_info[0] == 0:
         print("No favorite stored in slot {}".format(args.favorite_slot))
@@ -128,9 +125,7 @@ def main_options():
             'get',
             help = 'Get a favorite or favorites',
             prog = cmd_util+' get')
-    valid_slots = [str(num) for num in range(0, 14)]
-    valid_slots.append('all')
-    get_parser.add_argument("favorite_slot", help='specify context (e.g. Lycos.com)', choices=valid_slots, type=str)
+    get_parser.add_argument("favorite_slot", help='specify context (e.g. Lycos.com)', choices=range(0,14), type=int)
 
     # set
     # ---
@@ -147,6 +142,12 @@ def main_options():
             prog=cmd_util+' del')
     del_parser.add_argument("favorite_slot", type=int, help='specify context (e.g. Lycos.com)', choices=range(0,14))
 
+    # list
+    # ----
+    list_parser = subparsers.add_parser(
+            'list',
+            help = 'List all favorites',
+            prog = cmd_util+' list')
 
     if not len(sys.argv) > 1:
         parser.print_help()
@@ -161,7 +162,8 @@ def main():
     command_handlers = {
         'get':get_favorite,
         'set':set_favorite,
-        'del':del_favorite
+        'del':del_favorite,
+        'list':list_favorites
     }
 
     args = main_options()
@@ -202,14 +204,3 @@ def main():
 if __name__ == '__main__':
 
     main()
-
-    # TODO: Crucial
-    #   * Input validation
-    # TODO: Important
-    #   * Implement get password
-    #   * Canceling request to add context loops and can't be terminated.
-    #   * Call .check_password() before setting password to avoid superfluous
-    #     prompting of the user.
-    #   * Implement --length and --skip
-    # TODO: Eventually
-    #   * Implement delete

--- a/mooltipy/utilities/mpfavorites.py
+++ b/mooltipy/utilities/mpfavorites.py
@@ -31,8 +31,28 @@ except NameError:
     # For python 2/3 compatibility
     pass
 
+def get_all_favorites(mooltipass, args):
+    favorites = []
+    for slot in range(0, 14):
+        fav_slot_info = mooltipass.get_favorite(slot)
+        if fav_slot_info[0] != 0:
+            favorites.append((slot, fav_slot_info))
+    if not len(favorites):
+        print("No favorites configured!")
+    else:
+        for favorite in favorites:
+            context_info = mooltipass.read_node(favorite[1][0])
+            child_info = mooltipass.read_node(favorite[1][1])
+            print("Favorite Slot {} - {}:{}".format(favorite[0],
+                                                    context_info.service_name,
+                                                    child_info.login))
+
 def get_favorite(mooltipass, args):
     """Gets the favorite information from the specified slot"""
+    if args.favorite_slot == 'all':
+        get_all_favorites(mooltipass, args)
+        return
+    args.favorite_slot = int(args.favorite_slot)
     fav_slot_info = mooltipass.get_favorite(args.favorite_slot)
     if fav_slot_info[0] == 0:
         print("No favorite stored in slot {}".format(args.favorite_slot))
@@ -109,7 +129,9 @@ def main_options():
             'get',
             help = 'Get a favorite or favorites',
             prog = cmd_util+' get')
-    get_parser.add_argument("favorite_slot", type=int, help='specify context (e.g. Lycos.com)', choices=range(0,14))
+    valid_slots = [str(num) for num in range(0, 14)]
+    valid_slots.append('all')
+    get_parser.add_argument("favorite_slot", help='specify context (e.g. Lycos.com)', choices=valid_slots, type=str)
 
     # set
     # ---


### PR DESCRIPTION
Added favorites list feature.

Spent some time to cleanup and refactor the usage of recv_packet so that the same pattern of self.recv_packet()[self._DATA_INDEX:] can be eliminated. It is now behind the scenes of recv_packet, as we now return the buffer of recv_packet minus the data length sent back, which is returned as well. Returning both allows us to easily unpack strings sent by the Mooltipass
