### PR TITLE
Add list and range validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ MYNOTES
 example.py
 venv
 *.out
+*.swo

--- a/mooltipy/mooltipass.py
+++ b/mooltipy/mooltipass.py
@@ -30,6 +30,11 @@ import usb.core
 
 from .constants import *
 
+from collections import namedtuple
+
+MooltipassParam = namedtuple("MooltipassParam",
+                             "param, formatter, allowed_range")
+
 # Uncomment for lots of debugging
 #logging.basicConfig(level=logging.DEBUG)
 
@@ -44,23 +49,23 @@ class _Mooltipass(object):
     """valid_params contains a dictionary of all valid mooltipass
     configuration parameters and their internal mapping"""
     valid_params = {
-            'keyboard_layout'    : (KEYBOARD_LAYOUT_PARAM, hex),
-            'user_intr_timer'    : (USER_INTER_TIMEOUT_PARAM, int),
-            'lock_timeout_enable': (LOCK_TIMEOUT_ENABLE_PARAM, bool),
-            'lock_timeout'       : (LOCK_TIMEOUT_PARAM, int),
-            'touch_di'           : (TOUCH_DI_PARAM, int),
+            'keyboard_layout'    : MooltipassParam(KEYBOARD_LAYOUT_PARAM, hex, range(128+18, 128+39)),
+            'user_intr_timer'    : MooltipassParam(USER_INTER_TIMEOUT_PARAM, int, range(0, 0xFF)),
+            'lock_timeout_enable': MooltipassParam(LOCK_TIMEOUT_ENABLE_PARAM, bool, [0, 1]),
+            'lock_timeout'       : MooltipassParam(LOCK_TIMEOUT_PARAM, int, range(0, 0xFF)),
+            'touch_di'           : MooltipassParam(TOUCH_DI_PARAM, int, range(0, 0xFF)),
             # TOUCH_WHEEL_OS_PARAM_OLD - Not used anymore
-            'touch_prox_os'      : (TOUCH_PROX_OS_PARAM, hex),
-            'offline_mode'       : (OFFLINE_MODE_PARAM, bool),
-            'screensaver'        : (SCREENSAVER_PARAM, bool),
-            'touch_charge_time'  : (TOUCH_CHARGE_TIME_PARAM, int),
-            'touch_wheel os_0'   : (TOUCH_WHEEL_OS_PARAM0, hex),
-            'touch_wheel os_1'   : (TOUCH_WHEEL_OS_PARAM1, hex),
-            'touch_wheel os_2'   : (TOUCH_WHEEL_OS_PARAM2, hex),
-            'flash_screen'       : (FLASH_SCREEN_PARAM, bool),
-            'user_req_cancel'    : (USER_REQ_CANCEL_PARAM, bool),
-            'tutorial'           : (TUTORIAL_BOOL_PARAM, bool),
-            'screen_saver_speed' : (SCREEN_SAVER_SPEED_PARAM, int)
+            'touch_prox_os'      : MooltipassParam(TOUCH_PROX_OS_PARAM, hex, range(0, 0xFF)),
+            'offline_mode'       : MooltipassParam(OFFLINE_MODE_PARAM, bool, [0, 1]),
+            'screensaver'        : MooltipassParam(SCREENSAVER_PARAM, bool, [0, 1]),
+            'touch_charge_time'  : MooltipassParam(TOUCH_CHARGE_TIME_PARAM, int, range(0, 0xFF)),
+            'touch_wheel os_0'   : MooltipassParam(TOUCH_WHEEL_OS_PARAM0, hex, range(0, 0xFF)),
+            'touch_wheel os_1'   : MooltipassParam(TOUCH_WHEEL_OS_PARAM1, hex, range(0, 0xFF)),
+            'touch_wheel os_2'   : MooltipassParam(TOUCH_WHEEL_OS_PARAM2, hex, range(0, 0xFF)),
+            'flash_screen'       : MooltipassParam(FLASH_SCREEN_PARAM, bool, [0, 1]),
+            'user_req_cancel'    : MooltipassParam(USER_REQ_CANCEL_PARAM, bool, [0, 1]),
+            'tutorial'           : MooltipassParam(TUTORIAL_BOOL_PARAM, bool, [0, 1]),
+            'screen_saver_speed' : MooltipassParam(SCREEN_SAVER_SPEED_PARAM, int, range(0, 0xFF))
             }
 
     _PKT_LEN_INDEX = 0x00

--- a/mooltipy/mooltipass.py
+++ b/mooltipy/mooltipass.py
@@ -44,7 +44,23 @@ class _Mooltipass(object):
     """valid_params contains a dictionary of all valid mooltipass
     configuration parameters and their internal mapping"""
     valid_params = {
-            'screen_saver_speed' : SCREEN_SAVER_SPEED_PARAM,
+            'keyboard_layout'    : (KEYBOARD_LAYOUT_PARAM, hex),
+            'user_intr_timer'    : (USER_INTER_TIMEOUT_PARAM, int),
+            'lock_timeout_enable': (LOCK_TIMEOUT_ENABLE_PARAM, bool),
+            'lock_timeout'       : (LOCK_TIMEOUT_PARAM, int),
+            'touch_di'           : (TOUCH_DI_PARAM, int),
+            # TOUCH_WHEEL_OS_PARAM_OLD - Not used anymore
+            'touch_prox_os'      : (TOUCH_PROX_OS_PARAM, hex),
+            'offline_mode'       : (OFFLINE_MODE_PARAM, bool),
+            'screensaver'        : (SCREENSAVER_PARAM, bool),
+            'touch_charge_time'  : (TOUCH_CHARGE_TIME_PARAM, int),
+            'touch_wheel os_0'   : (TOUCH_WHEEL_OS_PARAM0, hex),
+            'touch_wheel os_1'   : (TOUCH_WHEEL_OS_PARAM1, hex),
+            'touch_wheel os_2'   : (TOUCH_WHEEL_OS_PARAM2, hex),
+            'flash_screen'       : (FLASH_SCREEN_PARAM, bool),
+            'user_req_cancel'    : (USER_REQ_CANCEL_PARAM, bool),
+            'tutorial'           : (TUTORIAL_BOOL_PARAM, bool),
+            'screen_saver_speed' : (SCREEN_SAVER_SPEED_PARAM, int)
             }
 
     _PKT_LEN_INDEX = 0x00

--- a/mooltipy/utilities/mpparams.py
+++ b/mooltipy/utilities/mpparams.py
@@ -34,6 +34,14 @@ def set_param(mooltipass, args):
     if success != 1:
         print("Failed to set parameter {} to {}".format(mooltipass.valid_params[args.param], args.value))
 
+def list_params(mooltipass, args):
+    print("Current Mooltipass Parameters")
+    print("-----------------------------")
+    for param_name, param in sorted(mooltipass.valid_params.iteritems()):
+        param, formatter = (param)
+        value = mooltipass.get_param(param)
+        print("{:<20}: {}".format(param_name, formatter(value)))
+
 def main_options():
     """Handles command-line interface, arguments & options. """
 
@@ -79,6 +87,13 @@ def main_options():
     set_parser.add_argument("param", help='Which parameter to set', choices=MooltipassClient.valid_params.keys())
     set_parser.add_argument("value", help='Value to set for a parameter')
 
+    # list
+    # ----
+    list_parser = subparsers.add_parser(
+            'list',
+            help = 'List the current value of all known parameters',
+            prog = cmd_util+' list')
+
     if not len(sys.argv) > 1:
         parser.print_help()
         sys.exit(0)
@@ -92,6 +107,7 @@ def main():
     command_handlers = {
         'get':get_param,
         'set':set_param,
+        'list':list_params,
     }
 
     args = main_options()

--- a/mooltipy/utilities/mpparams.py
+++ b/mooltipy/utilities/mpparams.py
@@ -30,7 +30,10 @@ def get_param(mooltipass, args):
     print("Current value of {}: {}".format(args.param, value))
 
 def set_param(mooltipass, args):
-    success = mooltipass.set_param(mooltipass.valid_params[args.param], int(args.value))
+    if args.value not in mooltipass.valid_params[args.param].allowed_range:
+        print("The value {} for {} is not in the allowed range {}",
+              args.value, args.param, mooltipass.valid_params[args.param].allowed_range)
+    success = mooltipass.set_param(mooltipass.valid_params[args.param].param, args.value)
     if success != 1:
         print("Failed to set parameter {} to {}".format(mooltipass.valid_params[args.param], args.value))
 
@@ -38,9 +41,11 @@ def list_params(mooltipass, args):
     print("Current Mooltipass Parameters")
     print("-----------------------------")
     for param_name, param in sorted(mooltipass.valid_params.iteritems()):
-        param, formatter = (param)
-        value = mooltipass.get_param(param)
-        print("{:<20}: {}".format(param_name, formatter(value)))
+        value = mooltipass.get_param(param.param)
+        print("{:<20}: {}".format(param_name, param.formatter(value)))
+
+def auto_int(x):
+    return int(x, 0)
 
 def main_options():
     """Handles command-line interface, arguments & options. """
@@ -85,7 +90,7 @@ def main_options():
             help = 'Set or update a favorite',
             prog = cmd_util+' set')
     set_parser.add_argument("param", help='Which parameter to set', choices=MooltipassClient.valid_params.keys())
-    set_parser.add_argument("value", help='Value to set for a parameter')
+    set_parser.add_argument("value", help='Value to set for a parameter', type=auto_int)
 
     # list
     # ----


### PR DESCRIPTION
Added "mooltipy parameters list" to show the current value of all settings on the mooltipass
Cleaned up the code to add range validation.

It'd be nice if there was a better way to do the range validation, but this seems pretty simple to implement without adding a parser for each different command.
