### PR TITLE
Copy skip memory management options from mpfavorites to mplogin/mpdata

### DIFF
--- a/mooltipy/mooltipass.py
+++ b/mooltipy/mooltipass.py
@@ -432,7 +432,7 @@ class _Mooltipass(object):
 
         Return 1 or 0 indicating success or failure.
         """
-        # TODO: Where are paremeters documented?
+        # TODO: Where are parameters documented?
         logging.info('Not yet implemented')
         pass
 
@@ -636,7 +636,7 @@ class _Mooltipass(object):
         """
         logging.info('Not yet implemented')
         # CPZ should be returned... presumably in 32 byte chunks in a
-        # fashion simliar to reading data until 0x00 is encountered.
+        # fashion similar to reading data until 0x00 is encountered.
         # Mooltipass returns just 0x00 on error.
         pass
 
@@ -681,7 +681,7 @@ class _Mooltipass(object):
                 if data_len == 7:
                     break
         except usb.core.USBError:
-            # Skip timeout once all packets are recieved
+            # Skip timeout once all packets are received
             pass
 
         return recv
@@ -717,7 +717,7 @@ class _Mooltipass(object):
         """Get favorite for current user by slot ID. (0xC7)
 
         Arguments:
-            slot_id -- Slot ID of favorite to retieve.
+            slot_id -- Slot ID of favorite to retrieve.
 
         Return None on error or parent_addr, child_addr tuple (each
         address is 2 bytes).

--- a/mooltipy/mooltipass_client.py
+++ b/mooltipy/mooltipass_client.py
@@ -446,7 +446,7 @@ class ChildNode(Node):
             prev_child_node.write()
 
         # If there is a next_child_node, its prev_child_addr must be updated
-        if self.next_child_addr <> 0:
+        if self.next_child_addr != 0:
             next_child_node = self._parent._parent.read_node(self.next_child_addr, self._parent)
             next_child_node.prev_child_addr = self.prev_child_addr
             next_child_node.write()

--- a/mooltipy/utilities/mooltipy_wrapper.py
+++ b/mooltipy/utilities/mooltipy_wrapper.py
@@ -40,7 +40,7 @@ def main_options():
         utility_list += ' '*7 + key + ' ' * (12-len(key)) + '- ' + value.__doc__ + '\n'
 
     usage = 'Usage: %(prog)s UTILITY <arguments & options>\n' + \
-            'Avalilable utilities:\n' + \
+            'Available utilities:\n' + \
             utility_list
 
     parser = argparse.ArgumentParser(usage=usage)

--- a/mooltipy/utilities/mpdata.py
+++ b/mooltipy/utilities/mpdata.py
@@ -48,6 +48,13 @@ def main_options():
     # main
     parser = argparse.ArgumentParser(usage = usage, description=description)
 
+    parser.add_argument('-sme', '--skip_mgmt_enter',
+                        help='Skip entering management mode',
+                        action='store_true')
+    parser.add_argument('-smx', '--skip_mgmt_exit',
+                        help='Skip exiting management mode',
+                        action='store_true')
+
     # subparser
     subparsers = parser.add_subparsers(
             dest = 'command', help='action to take on context')
@@ -172,17 +179,20 @@ def del_context(mooltipass, args):
     if not mooltipass.set_data_context(args.context):
         raise RuntimeError('That context ({}) does not exist.'.format(args.context))
 
-    mooltipass.start_memory_management()
+    if args.skip_mgmt_enter == False:
+        mooltipass.start_memory_management()
 
     for pnode in mooltipass.parent_nodes('data'):
         if pnode.service_name == args.context:
             pnode.delete()
 
-    mooltipass.end_memory_management()
+    if args.skip_mgmt_exit == False:
+        mooltipass.end_memory_management()
 
 def list_context(mooltipass, args):
     """Display a list of data contexts."""
-    mooltipass.start_memory_management()
+    if args.skip_mgmt_enter == False:
+        mooltipass.start_memory_management()
     s = '{:<40}{:<40}\n'.format('Context:','Approximate Size:')
     s += '{:<40}{:<40}\n'.format('--------','----------------')
     for pnode in mooltipass.parent_nodes('data'):
@@ -192,7 +202,8 @@ def list_context(mooltipass, args):
             c += 1
         s += '{:<40}{:<40}\n'.format(service_name, c*128)
     print(s)
-    mooltipass.end_memory_management()
+    if args.skip_mgmt_exit == False:
+        mooltipass.end_memory_management()
 
 def main():
 

--- a/mooltipy/utilities/mpdata.py
+++ b/mooltipy/utilities/mpdata.py
@@ -240,7 +240,7 @@ def main():
 
         command_handlers[args.command](mooltipass, args)
         sys.exit(0)
-    except KeyboardInterrupt, SystemExit:
+    except (KeyboardInterrupt, SystemExit):
         print('')
         pass
     except Exception as e:

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -341,7 +341,7 @@ def main():
 
         command_handlers[args.command](mooltipass, args)
         sys.exit(0)
-    except KeyboardInterrupt, SystemExit:
+    except (KeyboardInterrupt, SystemExit):
         pass
     except Exception as e:
         print('An error occurred: \n{}'.format(e))

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -186,6 +186,10 @@ def main_options():
                 args.charset in ['an', 'alnum', 'alphanum', 'alphanumeric']:
             args.charset = 'an'
 
+        # Ask for password if -p was specified
+        if args.password != None and len(args.password) == 0:
+            args.password = getpass.getpass('Enter the password to use:')
+
     return args
 
 def get_context(mooltipass, args):
@@ -247,10 +251,6 @@ def set_context(mooltipass, args):
     # Generate a random password if no -p argument specified
     if args.password is None:
         args.password = generate_random_password(args)
-
-    # Ask for password if -p was specified
-    if len(args.password) == 0:
-        args.password = getpass.getpass('Enter the password to use:')
 
     # append tab/crlf to credentials
     append = {

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -87,7 +87,7 @@ def main_options():
             'Examples:\n' \
             '\t# Set a random passord for user_name at the example.com context' \
             '\n\t$ {cmd_util} set login example.com -u user_name\n\n' \
-            '\t# Set an alphanumeric password for user_name at the exemple.com context' \
+            '\t# Set an alphanumeric password for user_name at the example.com context' \
             '\n\t$ {cmd_util} set login example.com -u user_name -c alnum\n\n' \
             '\t# Set a password for user_name, but ask for it at runtime ' \
             '\n\t$ {cmd_util} set login example.com -u user_name -p\n\n' \
@@ -108,9 +108,9 @@ def main_options():
             '-p','--password',
             help = 'do not set this option to generate a random password ' + \
                    '(best method); set this option without specifying a ' + \
-                   'password to be promted at runtime for the password (ok ' + \
+                   'password to be prompted at runtime for the password (ok ' + \
                    'method); set this option and specify a password at the ' + \
-                   'same time on the command line (terrble method unless ' + \
+                   'same time on the command line (terrible method unless ' + \
                    'you\'re scripting)',
             nargs = '?',
             default = None,             # Set if -p not present
@@ -244,7 +244,7 @@ def generate_random_password(args):
 def set_context(mooltipass, args):
     """Create context and add or update a username & set the password."""
 
-    # Fixs if password legth is at max 31 chars and appended char requested
+    # Fixes if password length is at max 31 chars and appended char requested
     if args.ap and args.length == 31:
         args.length -= 1
 

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -351,6 +351,3 @@ def main():
 if __name__ == '__main__':
 
     main()
-
-    # TODO: Eventually
-    #   * Implement delete

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -48,6 +48,13 @@ def main_options():
     # main
     parser = argparse.ArgumentParser(usage = usage, description=description)
 
+    parser.add_argument('-sme', '--skip_mgmt_enter',
+                        help='Skip entering management mode',
+                        action='store_true')
+    parser.add_argument('-smx', '--skip_mgmt_exit',
+                        help='Skip exiting management mode',
+                        action='store_true')
+
     # subparser
     subparsers = parser.add_subparsers(
             dest = 'command', help='action to take on context')
@@ -202,7 +209,8 @@ def get_context(mooltipass, args):
 
 def list_context(mooltipass, args):
     """List login contexts"""
-    mooltipass.start_memory_management()
+    if args.skip_mgmt_enter == False:
+        mooltipass.start_memory_management()
 
     s = '{:<40}{:<40}\n'.format('Context:','Login(s):')
     s += '{:<40}{:<40}\n'.format('--------','---------')
@@ -214,7 +222,8 @@ def list_context(mooltipass, args):
                 service_name = ''
 
     print(s)
-    mooltipass.end_memory_management()
+    if args.skip_mgmt_exit == False:
+        mooltipass.end_memory_management()
 
 def generate_random_password(args):
     """Generate and return a random password."""
@@ -283,7 +292,8 @@ def del_context(mooltipass, args):
     if not mooltipass.set_context(args.context):
         raise RuntimeError('That context ({}) does not exist.'.format(args.context))
 
-    mooltipass.start_memory_management()
+    if args.skip_mgmt_enter == False:
+        mooltipass.start_memory_management()
 
     for pnode in mooltipass.parent_nodes('login'):
         if pnode.service_name == args.context:
@@ -294,7 +304,8 @@ def del_context(mooltipass, args):
             else:
                 pnode.delete()
 
-    mooltipass.end_memory_management()
+    if args.skip_mgmt_exit == False:
+        mooltipass.end_memory_management()
 
 def main():
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-pycrypto==2.6.1
-pyusb==1.0.0b2
+pyusb>=1.0.0b2

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
             'Intended Audience :: End Users/Desktop',
     ],
     packages = find_packages(),
-    install_requires = ['pycrypto', 'pyusb==1.0.0b2'],
+    install_requires = ['pyusb>=1.0.0b2'],
     entry_points = {
         'console_scripts': [
             'mooltipy = mooltipy.utilities.mooltipy_wrapper:main',


### PR DESCRIPTION
The mpfavorites utility already has the -sme and -smx options to allow
the entry and exiting of memory management mode to be skipped.  This
change copies those options to the mplogin and mpdata utilities so
that multiple commands that require memory management mode can be
performed without having to go through the hassle of entering your PIN
for each command.