### PR TITLE
Don't reenter Memory Management Mode if already in it.

### DIFF
--- a/mooltipy/mooltipass_client.py
+++ b/mooltipy/mooltipass_client.py
@@ -121,6 +121,10 @@ class MooltipassClient(_Mooltipass):
             raise RuntimeError('Cannot enter memory management mode; ' + \
                     'mooltipass not unlocked.')
 
+        # Already in memory management mode if we can get starting parent
+        if super(MooltipassClient, self).get_starting_parent_address():
+            return True
+
         return super(MooltipassClient, self).start_memory_management(timeout)
 
     def write_data_context(self, data, callback=None):


### PR DESCRIPTION
start_memory_management() would always tell the Mooltipass to start
Memory Management Mode (MMM) even if the Mooltipass was already in MMM
which causes the user to reenter their PIN.

This change enhances mooltipass_client's start_memory_management() to
call get_starting_parent_address() before calling the super's
start_memory_management().  If get_starting_parent_address() succeeds,
we know the Mooltipass is already in MMM so the super's
start_memory_management() doesn't need to be called and the user won't
have to reenter their PIN.