### PR TITLE
Improve Python 3 support, add --username and --with-context to get login

### DIFF
--- a/mooltipy/mooltipass.py
+++ b/mooltipy/mooltipass.py
@@ -291,7 +291,7 @@ class _Mooltipass(object):
             3 -- No card inserted into mooltipass
         """
 
-        self.send_packet(CMD_CONTEXT, array('B', context + b'\x00'))
+        self.send_packet(CMD_CONTEXT, array('B', bytes(context, 'ascii') + b'\x00'))
         recv, _ = self.recv_packet(10000)
         return recv[0]
 
@@ -324,7 +324,7 @@ class _Mooltipass(object):
 
         Return 1 or 0 indicating success or failure.
         """
-        self.send_packet(CMD_SET_LOGIN, array('B', login + b'\x00'))
+        self.send_packet(CMD_SET_LOGIN, array('B', bytes(login, 'ascii') + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 
@@ -333,7 +333,7 @@ class _Mooltipass(object):
 
         Return 1 or 0 indicating success or failure.
         """
-        self.send_packet(CMD_SET_PASSWORD, array('B', password + b'\x00'))
+        self.send_packet(CMD_SET_PASSWORD, array('B', bytes(password, 'ascii') + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 
@@ -349,7 +349,7 @@ class _Mooltipass(object):
         # A timer blocks repeated checking of passwords.
         # A return of 0x02 means the timer is still counting down.
         while recv is None or recv == 0x02:
-            self.send_packet(CMD_CHECK_PASSWORD, array('B', password + b'\x00'))
+            self.send_packet(CMD_CHECK_PASSWORD, array('B', bytes(password, 'ascii') + b'\x00'))
             recv, _ = self.recv_packet()
             recv = recv[0]
             time.sleep(.2)
@@ -361,7 +361,7 @@ class _Mooltipass(object):
 
         Return 1 or 0 indicating success or failure.
         """
-        self.send_packet(CMD_ADD_CONTEXT, array('B', context + b'\x00'))
+        self.send_packet(CMD_ADD_CONTEXT, array('B', bytes(context, 'ascii') + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 
@@ -548,7 +548,7 @@ class _Mooltipass(object):
 
         Return 1 or 0 indicating success or failure.
         """
-        self.send_packet(CMD_SET_DATA_SERVICE, array('B', context + b'\x00'))
+        self.send_packet(CMD_SET_DATA_SERVICE, array('B', bytes(context, 'ascii') + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 
@@ -561,7 +561,7 @@ class _Mooltipass(object):
         Return 1 or 0 indicating success or failure.
         """
         print('sending ' + context)
-        self.send_packet(CMD_ADD_DATA_SERVICE, array('B', context + b'\x00'))
+        self.send_packet(CMD_ADD_DATA_SERVICE, array('B', bytes(context, 'ascii') + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 

--- a/mooltipy/mooltipass.py
+++ b/mooltipy/mooltipass.py
@@ -295,12 +295,16 @@ class _Mooltipass(object):
         recv, _ = self.recv_packet(10000)
         return recv[0]
 
-    def get_login(self):
+    def get_login(self, username):
         """Get the login for current context. (0xA4)
 
         Returns the login as a string or 0 on failure.
         """
-        self.send_packet(CMD_GET_LOGIN, None)
+        if username == '':
+            username = None
+        else:
+            username = bytes(username, 'ascii') + b'\x00'
+        self.send_packet(CMD_GET_LOGIN, username)
         recv, data_len = self.recv_packet()
         if recv[0] == 0:
             return 0

--- a/mooltipy/mooltipass_client.py
+++ b/mooltipy/mooltipass_client.py
@@ -320,8 +320,7 @@ class ParentNode(Node):
 
     @property
     def service_name(self):
-        service_name = [c for c in struct.unpack('<58s', self.raw[8:66])[0]]
-        return ''.join(service_name[:service_name.index('\x00')])
+        return struct.unpack('<58s', self.raw[8:66])[0].strip(b'\0')
 
     def __str__(self):
         return "<{}: Address:0x{:x}, PrevParent:0x{:x}, NextParent:0x{:x}, NextChild:0x{:x}, ServiceName:{}>".format(self.__class__.__name__, self.node_addr, self.prev_parent_addr, self.next_parent_addr, self.next_child_addr, self.service_name)

--- a/mooltipy/mooltipass_client.py
+++ b/mooltipy/mooltipass_client.py
@@ -412,7 +412,7 @@ class ChildNode(Node):
 
     @property
     def login(self):
-        return struct.unpack('<63s', self.raw[37:100])[0].strip('\0')
+        return struct.unpack('<63s', self.raw[37:100])[0].strip(b'\0')
 
     @login.setter
     def login(self, value):

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -66,15 +66,15 @@ def main_options():
             description = description,
             prog = cmd_util+' get')
     # TODO: accept username as an argument
-    #get_parser.add_argument('-u','--username',
-    #        help = 'optional username for the context',
-    #        default = '',
-    #        action = 'store')
+    get_parser.add_argument('-u','--username',
+            help = 'optional username for the context',
+            default = '',
+            action = 'store')
     get_parser.add_argument("context", help='specify context (e.g. Lycos.com)')
     get_parser.add_argument(
         '-w', '--with-username',
         help = 'Return username on first line, password on second.',
-        dest = 'username',
+        dest = 'with_username',
         default = False,
         action = 'store_true')
 
@@ -198,13 +198,14 @@ def get_context(mooltipass, args):
         raise RuntimeError('Unlock the mooltipass and try again.')
 
     # Try to get password; 0 means there are multiple logins for this context
-    username = None
+    # and that --username was not used to specify which one to pick
+    username = mooltipass.get_login(args.username)
     password = mooltipass.get_password()
     if password == 0:
-        username = mooltipass.get_login()
+        username = mooltipass.get_login(args.username)
+        password = mooltipass.get_password()
 
-    password = mooltipass.get_password()
-    if args.username:
+    if args.with_username:
         print(username)
     print(password)
 

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -77,6 +77,12 @@ def main_options():
         dest = 'with_username',
         default = False,
         action = 'store_true')
+    get_parser.add_argument(
+        '-c', '--with-context',
+        help = 'Implies --with-username. Return context on first line, username on second line and password on third.',
+        dest = 'with_context',
+        default = False,
+        action = 'store_true')
 
     # set
     # ---
@@ -205,7 +211,9 @@ def get_context(mooltipass, args):
         username = mooltipass.get_login(args.username)
         password = mooltipass.get_password()
 
-    if args.with_username:
+    if args.with_context:
+        print(args.context)
+    if args.with_username or args.with_context:
         print(username)
     print(password)
 

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -242,8 +242,8 @@ def list_context(mooltipass, args):
     if args.dump:
         s = ''
     for pnode in mooltipass.parent_nodes('login'):
-        if fnmatch.fnmatch(pnode.service_name, args.context):
-            service_name = pnode.service_name
+        if fnmatch.fnmatch(pnode.service_name.decode(), args.context):
+            service_name = pnode.service_name.decode()
             context = service_name
             for cnode in pnode.child_nodes():
                 username = cnode.login.decode()

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -214,8 +214,8 @@ def get_context(mooltipass, args):
     if args.with_context:
         print(args.context)
     if args.with_username or args.with_context:
-        print(username)
-    print(password)
+        print(username.decode())
+    print(password.decode())
 
 def list_context(mooltipass, args):
     """List login contexts"""

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -235,10 +235,10 @@ def list_context(mooltipass, args):
     mooltipass.start_memory_management()
 
     if args.with_passwords:
-        s = '{:<40}{:<40}{:<40}\n'.format('Context:','Login(s):','Password(s):')
+        s = '{:<70}{:<70}{:<70}\n'.format('Context:','Login(s):','Password(s):')
     else:
-        s = '{:<40}{:<40}\n'.format('Context:','Login(s):')
-    s += '{:<40}{:<40}\n'.format('--------','---------')
+        s = '{:<70}{:<70}\n'.format('Context:','Login(s):')
+    s += '{:<70}{:<70}\n'.format('--------','---------')
     if args.dump:
         s = ''
     for pnode in mooltipass.parent_nodes('login'):
@@ -251,9 +251,9 @@ def list_context(mooltipass, args):
                     mooltipass.set_context(context)
                     mooltipass.get_login(username)
                     retpassword = mooltipass.get_password()
-                    s += '{:<40}{:<40}{:<40}\n'.format(service_name, username, retpassword.decode())
+                    s += '{:<70}{:<70}{:<70}\n'.format(service_name, username, retpassword.decode())
                 else:
-                    s += '{:<40}{:<40}\n'.format(service_name, username)
+                    s += '{:<70}{:<70}\n'.format(service_name, username)
                 if not args.dump:
                     service_name = ''
 

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -176,6 +176,13 @@ def main_options():
             default = '*',
             nargs = '?',
             help = 'supports shell-style wildcards; default is "*" showing all contexts.')
+    list_parser.add_argument(
+        '-d', '--dump',
+        help = 'List contexts and passwords in a way which would be simpler to parse by external tools.',
+        default = False,
+        action = 'store_true')
+
+
 
     if not len(sys.argv) > 1:
         parser.print_help()
@@ -223,12 +230,15 @@ def list_context(mooltipass, args):
 
     s = '{:<40}{:<40}\n'.format('Context:','Login(s):')
     s += '{:<40}{:<40}\n'.format('--------','---------')
+    if args.dump:
+        s = ''
     for pnode in mooltipass.parent_nodes('login'):
         if fnmatch.fnmatch(pnode.service_name, args.context):
             service_name = pnode.service_name
             for cnode in pnode.child_nodes():
                 s += '{:<40}{:<40}\n'.format(service_name, cnode.login)
-                service_name = ''
+                if not args.dump:
+                    service_name = ''
 
     print(s)
     if args.skip_mgmt_exit == False:

--- a/mooltipy/utilities/mpparams.py
+++ b/mooltipy/utilities/mpparams.py
@@ -40,7 +40,7 @@ def set_param(mooltipass, args):
 def list_params(mooltipass, args):
     print("Parameter           : init : current")
     print("--------------------------------------")
-    for param_name, param in sorted(mooltipass.valid_params.iteritems()):
+    for param_name, param in sorted(iter(mooltipass.valid_params.items())):
         value = mooltipass.get_param(param.param)
         print("{:<20}: {:<5}: {}".format(param_name, param.formatter(param.default_value), param.formatter(value)))
 


### PR DESCRIPTION
Hello,
We chatted a long time ago on IRC about improving python 3 support. I finally took the time to make a proper push request.
Two of the patches are about improving python 3 support. One of them is enforcing ASCII encoding for strings which are then converted to binary, before being sent to the mooltipass. I did not check the behaviour when using a different encoding than the default one on the mooltipass.
The second python 3 support patch should be much safer to apply, it is about how python iterates on a dict.
The remaining patches are about extending the login get command. I implemented a proposal for the --username option which was commented out. I also added a --with-context option, so the context is printed as well when we use get login. Note that --with-context implies --with-username, as this respect the hierarchical relationship between a context and a login.
A last patch is there to fix the output of login get, as it was outputting strings with a b'' decorator, like b'mypassword'.
Please note that as stated at the beginning, I haven't proceeded with extending testing, yet I can say that it works for me.
Please let me know if you want me to modify or improve anything so those patches can get merged.
Thank you! 