### PR TITLE
Python3

### DIFF
--- a/mooltipy/mooltipass.py
+++ b/mooltipy/mooltipass.py
@@ -32,6 +32,13 @@ from .constants import *
 
 from collections import namedtuple
 
+ENCODING = 'ascii'
+def str_from_array(arr):
+    """Retrieve null terminated ASCII string from array."""
+    # Change array to bytes, remove everything after first \0 and
+    # interpret as ASCII:
+    return arr.tobytes().partition(b'\0')[0].decode(ENCODING)
+
 MooltipassParam = namedtuple("MooltipassParam",
                              "param, formatter, allowed_range, default_value")
 
@@ -194,7 +201,10 @@ class _Mooltipass(object):
                     # Unit sends 0xB9 when user is entering their PIN.
                     break
                 elif recv[self._CMD_INDEX] == CMD_DEBUG:
-                    debug_msg = struct.unpack('{}s'.format(recv[self._PKT_LEN_INDEX]-1), recv[self._DATA_INDEX:recv[self._PKT_LEN_INDEX]+1])[0]
+                    # USB_MESSAGES_FOR_CRITICAL_CALLBACKS appears to not be
+                    # defined in production firmware builds so I was unable
+                    # to test this as part of the Python 3 port.
+                    debug_msg = str_from_array(recv[self._DATA_INDEX:recv[self._PKT_LEN_INDEX]+1])
                     if debug_msg == "#MBE":
                         print("Received Memory Boundary Error Callback!")
                     elif debug_msg == "#NM":
@@ -276,8 +286,7 @@ class _Mooltipass(object):
         """
         self.send_packet(CMD_VERSION, None)
         recv, data_len = self.recv_packet()
-        # TODO: TEST THIS
-        return struct.unpack('<b{}s'.format(data_len-1), recv[0:data_len])
+        return str_from_array(recv[:data_len])
 
     def set_context(self, context):
         """Set mooltipass context. (0xA3)
@@ -291,7 +300,7 @@ class _Mooltipass(object):
             3 -- No card inserted into mooltipass
         """
 
-        self.send_packet(CMD_CONTEXT, array('B', bytes(context, 'ascii') + b'\x00'))
+        self.send_packet(CMD_CONTEXT, array('B', bytes(context, ENCODING) + b'\x00'))
         recv, _ = self.recv_packet(10000)
         return recv[0]
 
@@ -305,7 +314,7 @@ class _Mooltipass(object):
         if recv[0] == 0:
             return 0
         else:
-            return struct.unpack('<{}s'.format(data_len), recv[:data_len])[0]
+            return str_from_array(recv[:data_len])
 
     def get_password(self):
         """Get the password for current context. (0xA5)
@@ -317,14 +326,14 @@ class _Mooltipass(object):
         if recv[0] == 0:
             return 0
         else:
-            return struct.unpack('<{}s'.format(data_len), recv[:data_len])[0]
+            return str_from_array(recv[:data_len])
 
     def set_login(self, login):
         """Set a login. (0xA6)
 
         Return 1 or 0 indicating success or failure.
         """
-        self.send_packet(CMD_SET_LOGIN, array('B', bytes(login, 'ascii') + b'\x00'))
+        self.send_packet(CMD_SET_LOGIN, array('B', bytes(login, ENCODING) + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 
@@ -333,7 +342,7 @@ class _Mooltipass(object):
 
         Return 1 or 0 indicating success or failure.
         """
-        self.send_packet(CMD_SET_PASSWORD, array('B', bytes(password, 'ascii') + b'\x00'))
+        self.send_packet(CMD_SET_PASSWORD, array('B', bytes(password, ENCODING) + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 
@@ -349,7 +358,7 @@ class _Mooltipass(object):
         # A timer blocks repeated checking of passwords.
         # A return of 0x02 means the timer is still counting down.
         while recv is None or recv == 0x02:
-            self.send_packet(CMD_CHECK_PASSWORD, array('B', bytes(password, 'ascii') + b'\x00'))
+            self.send_packet(CMD_CHECK_PASSWORD, array('B', bytes(password, ENCODING) + b'\x00'))
             recv, _ = self.recv_packet()
             recv = recv[0]
             time.sleep(.2)
@@ -361,7 +370,7 @@ class _Mooltipass(object):
 
         Return 1 or 0 indicating success or failure.
         """
-        self.send_packet(CMD_ADD_CONTEXT, array('B', bytes(context, 'ascii') + b'\x00'))
+        self.send_packet(CMD_ADD_CONTEXT, array('B', bytes(context, ENCODING) + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 
@@ -548,7 +557,7 @@ class _Mooltipass(object):
 
         Return 1 or 0 indicating success or failure.
         """
-        self.send_packet(CMD_SET_DATA_SERVICE, array('B', bytes(context, 'ascii') + b'\x00'))
+        self.send_packet(CMD_SET_DATA_SERVICE, array('B', bytes(context, ENCODING) + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 
@@ -561,7 +570,7 @@ class _Mooltipass(object):
         Return 1 or 0 indicating success or failure.
         """
         print('sending ' + context)
-        self.send_packet(CMD_ADD_DATA_SERVICE, array('B', bytes(context, 'ascii') + b'\x00'))
+        self.send_packet(CMD_ADD_DATA_SERVICE, array('B', bytes(context, ENCODING) + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 

--- a/mooltipy/mooltipass.py
+++ b/mooltipy/mooltipass.py
@@ -45,7 +45,7 @@ MooltipassParam = namedtuple("MooltipassParam",
 # Uncomment for lots of debugging
 #logging.basicConfig(level=logging.DEBUG)
 
-class _Mooltipass(object):
+class _Mooltipass:
     """Mooltipass -- Outlines access to Mooltipass's USB commands.
 
     This class is designed to be inherited (particularly by

--- a/mooltipy/mooltipass.py
+++ b/mooltipy/mooltipass.py
@@ -291,7 +291,7 @@ class _Mooltipass(object):
             3 -- No card inserted into mooltipass
         """
 
-        self.send_packet(CMD_CONTEXT, array('B', context + b'\x00'))
+        self.send_packet(CMD_CONTEXT, array('B', bytes(context, 'ascii') + b'\x00'))
         recv, _ = self.recv_packet(10000)
         return recv[0]
 
@@ -324,7 +324,7 @@ class _Mooltipass(object):
 
         Return 1 or 0 indicating success or failure.
         """
-        self.send_packet(CMD_SET_LOGIN, array('B', login + b'\x00'))
+        self.send_packet(CMD_SET_LOGIN, array('B', bytes(login, 'ascii') + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 
@@ -333,7 +333,7 @@ class _Mooltipass(object):
 
         Return 1 or 0 indicating success or failure.
         """
-        self.send_packet(CMD_SET_PASSWORD, array('B', password + b'\x00'))
+        self.send_packet(CMD_SET_PASSWORD, array('B', bytes(password, 'ascii') + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 
@@ -349,7 +349,7 @@ class _Mooltipass(object):
         # A timer blocks repeated checking of passwords.
         # A return of 0x02 means the timer is still counting down.
         while recv is None or recv == 0x02:
-            self.send_packet(CMD_CHECK_PASSWORD, array('B', password + b'\x00'))
+            self.send_packet(CMD_CHECK_PASSWORD, array('B', bytes(password, 'ascii') + b'\x00'))
             recv, _ = self.recv_packet()
             recv = recv[0]
             time.sleep(.2)
@@ -361,7 +361,7 @@ class _Mooltipass(object):
 
         Return 1 or 0 indicating success or failure.
         """
-        self.send_packet(CMD_ADD_CONTEXT, array('B', context + b'\x00'))
+        self.send_packet(CMD_ADD_CONTEXT, array('B', bytes(context, 'ascii') + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 
@@ -548,7 +548,7 @@ class _Mooltipass(object):
 
         Return 1 or 0 indicating success or failure.
         """
-        self.send_packet(CMD_SET_DATA_SERVICE, array('B', context + b'\x00'))
+        self.send_packet(CMD_SET_DATA_SERVICE, array('B', bytes(context, 'ascii') + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 
@@ -561,7 +561,7 @@ class _Mooltipass(object):
         Return 1 or 0 indicating success or failure.
         """
         print('sending ' + context)
-        self.send_packet(CMD_ADD_DATA_SERVICE, array('B', context + b'\x00'))
+        self.send_packet(CMD_ADD_DATA_SERVICE, array('B', bytes(context, 'ascii') + b'\x00'))
         recv, _ = self.recv_packet()
         return recv[0]
 

--- a/mooltipy/mooltipass_client.py
+++ b/mooltipy/mooltipass_client.py
@@ -523,10 +523,6 @@ class _ParentNodes(object):
     def __iter__(self):
         return self
 
-    def next(self):
-        # Python 2 compatibility
-        return self.__next__()
-
     def __next__(self):
         if self.next_parent_addr == 0:
             raise StopIteration()
@@ -558,10 +554,6 @@ class _ChildNodes(object):
 
     def __iter__(self):
         return self
-
-    def next(self):
-        #Python 2 compatibility
-        return self.__next__()
 
     def __next__(self):
         if self.next_addr == 0:

--- a/mooltipy/mooltipass_client.py
+++ b/mooltipy/mooltipass_client.py
@@ -43,7 +43,7 @@ class MooltipassClient(_Mooltipass):
     """
 
     def __init__(self):
-        super(MooltipassClient, self).__init__()
+        super().__init__()
         if not self.ping():
             raise RuntimeError('Mooltipass did not respond to ping.')
         version_info = self.get_version()
@@ -55,7 +55,7 @@ class MooltipassClient(_Mooltipass):
 
     @property
     def status(self):
-        return super(MooltipassClient, self).get_status()
+        return super().get_status()
 
     def ping(self):
         """Ping the mooltipass.
@@ -69,7 +69,7 @@ class MooltipassClient(_Mooltipass):
             data.append(random.randint(0,255))
             data.append(random.randint(0,255))
 
-            super(MooltipassClient, self).ping(data)
+            super().ping(data)
 
             recv = None
             while recv is None or \
@@ -78,7 +78,7 @@ class MooltipassClient(_Mooltipass):
                     recv[2] != data[2] or \
                     recv[3] != data[3]:
 
-                recv, _ = super(MooltipassClient, self).recv_packet()
+                recv, _ = super().recv_packet()
 
             logging.debug("Mooltipass replied to our ping message")
             return True
@@ -94,17 +94,17 @@ class MooltipassClient(_Mooltipass):
         None if no card is in the mooltipass.
         """
         resp = {0:False, 1:True, 3:None}
-        return resp[super(MooltipassClient, self).set_context(context)]
+        return resp[super().set_context(context)]
 
     def set_password(self, password):
         """Set password for current context and login.
 
         Return 1 or 0 indicating success or failure.
         """
-        if super(MooltipassClient, self).check_password(password):
+        if super().check_password(password):
             return 0
         else:
-            return super(MooltipassClient, self).set_password(password)
+            return super().set_password(password)
 
     def start_memory_management(self, timeout=20000):
         """Enter memory management mode.
@@ -123,10 +123,10 @@ class MooltipassClient(_Mooltipass):
                     'mooltipass not unlocked.')
 
         # Already in memory management mode if we can get starting parent
-        if super(MooltipassClient, self).get_starting_parent_address():
+        if super().get_starting_parent_address():
             return True
 
-        return super(MooltipassClient, self).start_memory_management(timeout)
+        return super().start_memory_management(timeout)
 
     def write_data_context(self, data, callback=None):
         """Write to mooltipass data context.
@@ -150,7 +150,7 @@ class MooltipassClient(_Mooltipass):
         ext_data = array('B', lod)
         ext_data.extend(data)
 
-        return super(MooltipassClient, self).write_data_context(ext_data, callback)
+        return super().write_data_context(ext_data, callback)
 
     def read_data_context(self, callback=None):
         """Read data from context. 
@@ -163,7 +163,7 @@ class MooltipassClient(_Mooltipass):
         Return data as array or None.
         """
 
-        data = super(MooltipassClient, self).read_data_context(callback)
+        data = super().read_data_context(callback)
         # See write_data_context for explanation of lod
         lod = struct.unpack('>L', data[:4])[0]
         logging.debug('Expecting: ' + str(lod) + ' bytes...')
@@ -183,7 +183,7 @@ class MooltipassClient(_Mooltipass):
                 functions & variables. Optional, and default assumes
                 the parent object is Mooltipassclient.
         """
-        recv = super(MooltipassClient, self).read_node(node_addr)
+        recv = super().read_node(node_addr)
         if parent_weak_ref == None:
             parent_weak_ref = weakref.ref(self)()
         # Use flags to figure out the node type
@@ -201,7 +201,7 @@ class MooltipassClient(_Mooltipass):
 
     def write_node(self, node):
         """Write to a node in memory."""
-        return super(MooltipassClient, self)._write_node(node.addr, node.raw)
+        return super()._write_node(node.addr, node.raw)
 
     def parent_nodes(self, node_type=None):
         """Return a ParentNodes iter.
@@ -226,7 +226,7 @@ class MooltipassClient(_Mooltipass):
         if not parent_addr in valid_addresses:
             raise RuntimeError('Can not set the starting parent to an invalid node address!')
 
-        return super(MooltipassClient, self)._set_starting_parent(parent_addr)
+        return super()._set_starting_parent(parent_addr)
 
     def set_starting_data_parent_addr(self, parent_addr):
         """Set the starting parent node.
@@ -241,10 +241,10 @@ class MooltipassClient(_Mooltipass):
         if not parent_addr in valid_addresses:
             raise RuntimeError('Can not set the starting parent to an invalid node address!')
 
-        return super(MooltipassClient, self)._set_starting_data_parent_addr(parent_addr)
+        return super()._set_starting_data_parent_addr(parent_addr)
 
 
-class Node(object):
+class Node:
     """Parent/Child/Data nodes have some similar, overlapping structure.
 
     The Node class is intended to be inherited by Parent/Child/DataNode classes.
@@ -293,11 +293,11 @@ class ParentNode(Node):
 
     @property
     def flags(self):
-        return super(ParentNode, self).flags
+        return super().flags
 
     @property
     def prev_parent_addr(self):
-        return super(ParentNode, self).first_addr
+        return super().first_addr
 
     @prev_parent_addr.setter
     def prev_parent_addr(self, value):
@@ -375,11 +375,11 @@ class ChildNode(Node):
 
     @property
     def flags(self):
-        return super(ChildNode, self).flags
+        return super().flags
 
     @property
     def prev_child_addr(self):
-        return super(ChildNode, self).first_addr
+        return super().first_addr
 
     @prev_child_addr.setter
     def prev_child_addr(self, value):
@@ -467,11 +467,11 @@ class DataNode(Node):
 
     @property
     def flags(self):
-        return super(DataNode, self).flags
+        return super().flags
 
     @property
     def next_data_addr(self):
-        return super(DataNode, self).first_addr
+        return super().first_addr
 
     @property
     def data(self):
@@ -492,7 +492,7 @@ class DataNode(Node):
         self.write()
 
 
-class _ParentNodes(object):
+class _ParentNodes:
     """Parent node iterator.
 
     Intended to be returned to the user by way of method from
@@ -532,7 +532,7 @@ class _ParentNodes(object):
         return self.current_node
 
 
-class _ChildNodes(object):
+class _ChildNodes:
     """Child [or Data] node iterator.
 
     Intended to be returned to the user by way of method from

--- a/mooltipy/utilities/mooltipy_wrapper.py
+++ b/mooltipy/utilities/mooltipy_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file is part of Mooltipy.
 #

--- a/mooltipy/utilities/mpdata.py
+++ b/mooltipy/utilities/mpdata.py
@@ -54,7 +54,7 @@ def main_options():
 
     # subparser
     subparsers = parser.add_subparsers(
-            dest = 'command', help='action to take on context')
+            dest = 'command', help='action to take on context', required=True)
 
     # get
     # ---

--- a/mooltipy/utilities/mpdata.py
+++ b/mooltipy/utilities/mpdata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file is part of Mooltipy.
 #

--- a/mooltipy/utilities/mpfavorites.py
+++ b/mooltipy/utilities/mpfavorites.py
@@ -25,12 +25,6 @@ import time
 
 from mooltipy.mooltipass_client import MooltipassClient
 
-try:
-    input = raw_input
-except NameError:
-    # For python 2/3 compatibility
-    pass
-
 def list_favorites(mooltipass, args):
     favorites = []
     for slot in range(0, 14):

--- a/mooltipy/utilities/mpfavorites.py
+++ b/mooltipy/utilities/mpfavorites.py
@@ -121,7 +121,7 @@ def main_options():
 
     # subparser
     subparsers = parser.add_subparsers(
-            dest = 'command', help='action to take on context')
+            dest = 'command', help='action to take on context', required=True)
 
     # get
     # ---

--- a/mooltipy/utilities/mpfavorites.py
+++ b/mooltipy/utilities/mpfavorites.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file is part of Mooltipy.
 #

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -54,7 +54,7 @@ def main_options():
 
     # subparser
     subparsers = parser.add_subparsers(
-            dest = 'command', help='action to take on context')
+            dest = 'command', help='action to take on context', required=True)
 
     # get
     # ---

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file is part of Mooltipy.
 #

--- a/mooltipy/utilities/mpparams.py
+++ b/mooltipy/utilities/mpparams.py
@@ -40,7 +40,7 @@ def set_param(mooltipass, args):
 def list_params(mooltipass, args):
     print("Parameter           : init : current")
     print("--------------------------------------")
-    for param_name, param in sorted(mooltipass.valid_params.iteritems()):
+    for param_name, param in sorted(iter(mooltipass.valid_params.items())):
         value = mooltipass.get_param(param.param)
         print("{:<20}: {:<5}: {}".format(param_name, param.formatter(param.default_value), param.formatter(value)))
 

--- a/mooltipy/utilities/mpparams.py
+++ b/mooltipy/utilities/mpparams.py
@@ -73,7 +73,7 @@ def main_options():
 
     # subparser
     subparsers = parser.add_subparsers(
-            dest = 'command', help='action to take on context')
+            dest = 'command', help='action to take on context', required=True)
 
     # get
     # ---

--- a/mooltipy/utilities/mpparams.py
+++ b/mooltipy/utilities/mpparams.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file is part of Mooltipy.
 #

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
     keywords = ['mooltipass'],
     classifiers = [
             'Programming Language :: Python',
-            'Programming Language :: Python :: 2',
             'Programming Language :: Python :: 3',
             'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
             'Operating System :: POSIX :: Linux',


### PR DESCRIPTION
I recently updated to Debian 11 which no longer includes Python 2 by default.  mooltipy was my last dependency on Python 2 so I decided it was time to port it to Python 3.  I saw dicebox had submitted a pull request for Python 3 support but I noticed that it didn't fix all the problems I ran into and it also included code unrelated to porting to Python 3.  In the hopes of improving the chances of being pulled, this pull request only makes changes related to Python 3 porting and is more comprehensive, but does incorporate some of dicebox's commits.

Note that this change removes all support for Python 2.  My thinking is that Python 2 was sunsetted over two years ago and so would be irrelevant for people pulling new code.  The old code will continue to live in github just in case someone needs mooltipy to run on Python 2 .

The code was tested by running mpdata.py, mpfavorites.py, mplogin.py and mpparams.py with all of their supported commands.

Resolves #20