### PR TITLE
Cleanup unused/unneeded statements and fix misspellings.

### DIFF
--- a/mooltipy/mooltipass.py
+++ b/mooltipy/mooltipass.py
@@ -21,7 +21,6 @@ from array import array
 
 import logging
 import platform
-import random
 import struct
 import sys
 import time
@@ -242,7 +241,7 @@ class _Mooltipass:
         # value.
         #
         # read_node() returns a valid len indicator not counting the cmd byte...
-        #   so subtracting 1 is incorrect, but works in all other cases. 
+        #   so subtracting 1 is incorrect, but works in all other cases.
 
         # Packet len includes the cmd byte, so subtract 1 to match the data len
         return recv[self._DATA_INDEX:], recv[self._PKT_LEN_INDEX]-1
@@ -377,12 +376,10 @@ class _Mooltipass:
     def _set_bootloader_password(self, password):
         """??? (0xAA)"""
         logging.info('Not yet implemented')
-        pass
 
     def _jump_to_bootloader(self):
         """??? (0xAB)"""
         logging.info('Not yet implemented')
-        pass
 
     def get_random_number(self):
         """Get 32 random bytes. (0xAC)"""
@@ -410,7 +407,6 @@ class _Mooltipass:
         Return 1 or 0 indicating success or failure.
         """
         logging.info('Not yet implemented')
-        pass
 
     def _media_import(self, data):
         """Send data to mooltipass. (0xAF)
@@ -422,7 +418,6 @@ class _Mooltipass:
         """
         #TODO: Ask for pointer to source containing formatting!
         logging.info('Not yet implemented')
-        pass
 
     def _end_media_import(self):
         """Request end media to Mooltipass. (0xB0)
@@ -430,7 +425,6 @@ class _Mooltipass:
         Return 1 or 0 indicating success or failure.
         """
         logging.info('Not yet implemented')
-        pass
 
     def _set_mooltipass_parameter(self, param_id, value):
         """Set a mooltipass parameter. (0xB1)
@@ -443,7 +437,6 @@ class _Mooltipass:
         """
         # TODO: Where are parameters documented?
         logging.info('Not yet implemented')
-        pass
 
     def _get_mooltipass_parameter(self, param_id):
         """Retrieve a mooltipass parameter (0xB2).
@@ -454,7 +447,6 @@ class _Mooltipass:
         Returns the parameter value.
         """
         logging.info('Not yet implemented')
-        pass
 
     def _reset_card(self):
         """Reset inserted card. (0xB3)
@@ -462,7 +454,6 @@ class _Mooltipass:
         Return 1 or 0 indicating success or failure.
         """
         logging.info('Not yet implemented')
-        pass
 
     def _read_card_login(self):
         """Read login stored inside smartcard. (0xB4)
@@ -470,7 +461,6 @@ class _Mooltipass:
         Returns login or None.
         """
         logging.info('Not yet implemented')
-        pass
 
     def _read_card_password(self):
         """Read password stored inside the smartcard. (0xB5)
@@ -480,7 +470,6 @@ class _Mooltipass:
         Returns password or None.
         """
         logging.info('Not yet implemented')
-        pass
 
     def _set_card_login(self, login):
         """Set card login stored inside smartcard. (0xB6)
@@ -493,7 +482,6 @@ class _Mooltipass:
         Return 1 or 0 indicating success or failure.
         """
         logging.info('Not yet implemented')
-        pass
 
     def _set_card_password(self, password):
         """Set password stored inside the smartcard. (0xB7)
@@ -506,7 +494,6 @@ class _Mooltipass:
         Return 1 or 0 indicating success or failure.
         """
         logging.info('Not yet implemented')
-        pass
 
     def _add_unknown_smartcard(self, cpz, ctr):
         """Instruct mooltipass to store an unknown smartcard. (0xB8)
@@ -517,7 +504,6 @@ class _Mooltipass:
         Return 1 or 0 indicating success or failure.
         """
         logging.info('Not yet implemented')
-        pass
 
     def get_status(self):
         """Return raw mooltipass status as int. (0xB9)
@@ -539,18 +525,15 @@ class _Mooltipass:
 
     def _set_date(self):
         """Set current date. (0xBB)"""
-        loggin.info('Not yet implemented')
-        pass
+        logging.info('Not yet implemented')
 
     def _set_mooltipass_uid(self):
         """Set the mooltipass UID. (0xBC)"""
-        loggin.info('Not yet implemented')
-        pass
+        logging.info('Not yet implemented')
 
     def _get_mooltipass_uid(self):
         """Get the mooltipass UID. (0xBD)"""
-        loggin.info('Not yet implemented')
-        pass
+        logging.info('Not yet implemented')
 
     def set_data_context(self, context):
         """Set the data context. (0xBE)
@@ -647,7 +630,6 @@ class _Mooltipass:
         # CPZ should be returned... presumably in 32 byte chunks in a
         # fashion similar to reading data until 0x00 is encountered.
         # Mooltipass returns just 0x00 on error.
-        pass
 
     def cancel_user_request(self):
         """Cancel user input request. (0xC3)
@@ -657,7 +639,6 @@ class _Mooltipass:
         always returned.
         """
         self.send_packet(CMD_CANCEL_USER_REQUEST, None)
-        return None
 
     # 0xC4 is reserved for response from Mooltipass.
 
@@ -784,7 +765,6 @@ class _Mooltipass:
         Returns CTR value or None on error.
         """
         logging.info('Not yet implemented')
-        pass
 
     def _set_ctr_value(self, ctr_value):
         """Set new CTR value. (0xCC)
@@ -795,7 +775,6 @@ class _Mooltipass:
         Return 1 or 0 indicating success or failure.
         """
         logging.info('Not yet implemented')
-        pass
 
     def add_cpz_ctr_value(self, cpz, ctr):
         pass
@@ -834,8 +813,6 @@ class _Mooltipass:
         parent_addr = \
             struct.unpack('h', recv[:2])[0]
         return (lambda ret: None if 0 else ret)(parent_addr)
-        logging.info('Not yet implemented')
-        pass
 
     def _set_starting_data_parent_addr(self, parent_addr):
         """Set the first address for data nodes. (0xD2)

--- a/mooltipy/mooltipass_client.py
+++ b/mooltipy/mooltipass_client.py
@@ -22,9 +22,6 @@ import weakref
 from .mooltipass import _Mooltipass
 from .mooltipass import str_from_array, ENCODING
 
-# Delete me after removing read_all_nodes
-from collections import defaultdict
-
 PARENT_NODE = 0x0000
 CHILD_NODE = 0x4000
 PARENT_DATA = 0x8000
@@ -110,7 +107,7 @@ class MooltipassClient(_Mooltipass):
         """Enter memory management mode.
 
         Keyword argument:
-            timeout -- how long to wait for user to complete entering pin 
+            timeout -- how long to wait for user to complete entering pin
                     (default 20000).
 
         Return true/false on success/failure. May raise RuntimeError
@@ -153,7 +150,7 @@ class MooltipassClient(_Mooltipass):
         return super().write_data_context(ext_data, callback)
 
     def read_data_context(self, callback=None):
-        """Read data from context. 
+        """Read data from context.
 
         Arguments:
             callback    -- Callback function which must accept a tuple
@@ -454,7 +451,7 @@ class ChildNode(Node):
             next_child_node.prev_child_addr = self.prev_child_addr
             next_child_node.write()
 
-        # Fill the node so it is not considered an oprhan
+        # Fill the node so it is not considered an orphan
         self.raw = array('B', b'\xff'*132)
         self.write()
 
@@ -487,7 +484,7 @@ class DataNode(Node):
         # child nodes is when we're deleting all child nodes so I don't believe
         # this is necessary.
 
-        # Fill the node so it is not considered an oprhan
+        # Fill the node so it is not considered an orphan
         self.raw = array('B', b'\xff'*132)
         self.write()
 

--- a/mooltipy/utilities/mpdata.py
+++ b/mooltipy/utilities/mpdata.py
@@ -113,12 +113,6 @@ def main_options():
             help = 'list login contexts',
             description = description,
             prog = cmd_util + ' list')
-    list_parser.add_argument(
-            'context',
-            action = 'store',
-            default = '*',
-            nargs = '?',
-            help='supports shell-style wildcards; default is "*" showing all contexts')
 
     if not len(sys.argv) > 1:
         parser.print_help()
@@ -225,7 +219,6 @@ def main():
 
     try:
         # Ensure Mooltipass status
-        quiet_bool = False
         if not mooltipass.get_status() == 5:
             print('Insert a card and unlock the Mooltipass or cancel with ctrl-c')
             while True:
@@ -237,7 +230,6 @@ def main():
         sys.exit(0)
     except (KeyboardInterrupt, SystemExit):
         print('')
-        pass
     except Exception as e:
         print('\nAn error occurred: \n{}'.format(e))
     finally:

--- a/mooltipy/utilities/mplogin.py
+++ b/mooltipy/utilities/mplogin.py
@@ -82,7 +82,7 @@ def main_options():
     # ---
     description = 'Create or modify a login context (e.g. credentials for example.com).\n\n' \
             'Examples:\n' \
-            '\t# Set a random passord for user_name at the example.com context' \
+            '\t# Set a random password for user_name at the example.com context' \
             '\n\t$ {cmd_util} set login example.com -u user_name\n\n' \
             '\t# Set an alphanumeric password for user_name at the example.com context' \
             '\n\t$ {cmd_util} set login example.com -u user_name -c alnum\n\n' \
@@ -326,7 +326,6 @@ def main():
 
     try:
         # Ensure Mooltipass status
-        quiet_bool = False
         if not mooltipass.get_status() == 5:
             print('Insert a card and unlock the Mooltipass or cancel with ctrl-c')
             while True:

--- a/mooltipy/utilities/mpparams.py
+++ b/mooltipy/utilities/mpparams.py
@@ -20,8 +20,6 @@
 import argparse
 import os
 import sys
-import logging
-import time
 
 from mooltipy.mooltipass_client import MooltipassClient
 


### PR DESCRIPTION
Includes:
1) removing unused imports,
2) removing unneeded pass statements,
3) removing unneeded return None,
4) removing code after return statements,
5) removing unused context argument from mpdata list command,
6) removing unused variables,
7) fixing "loggin" module references to "logging",
8) fixing a couple of misspellings in comments, and
9) fix a misspelling in printed description of mplogin.py.